### PR TITLE
fixes #8

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -25,7 +25,7 @@
                   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Packages <span class="caret"></span></a>
                   <ul class="dropdown-menu">
                     {% for page in site.pages %}{% if page.title %}
-                                {% if page.url != '/404.html' and page.title != 'blog' %}
+                                {% if page.url != '/404.html' and page.title != 'blog' and page.title != 'Pangeo Data'%}
                      <li>
                          <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
                      </li>

--- a/index.markdown
+++ b/index.markdown
@@ -1,5 +1,6 @@
 ---
 layout: page
+title: Pangeo Data
 description: "A community effort for big data geoscience"
 ---
 
@@ -66,7 +67,7 @@ This is an open group, and we invite anyone interested to join.
 ## Package Design Documents
 
 {% for page in site.pages %}{% if page.title %}
-  {% if page.url != '/404.html' and page.title != 'blog' %}
+  {% if page.url != '/404.html' and page.title != 'blog' and page.title != 'Pangeo Data' %}
 - [{{page.title}}]({{ page.url | prepend: site.baseurl }})
   {% endif %}
  {% endif %}{% endfor %}


### PR DESCRIPTION
The jekyll version on github pages seems to handle the index page differently than my local version. Here it seems to be treated as a normal page and, as such, it requires a title.